### PR TITLE
WIP: Do not merge: A potential recipe for handing VC versions.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,19 +11,20 @@ source:
 
 build:
    number: 0
+
+   {% set VC_VERSION = os.environ.get('VC_VERSION', '15.0') %}
+   msvc_compiler: {{ VC_VERSION }}
    features:
-     - vc9      [win and py27]
-     - vc10     [win and py34]
-     - vc14     [win and py35]
+     - vc{{ VC_VERSION.split('.')[0] }}  # [win]
 
 requirements:
   build:
-    - gmp      [not win]
+    - vc  # [win]
+    - gmp  #[not win]
 
   run:
-    # python is a Windows run dependency in order to get the correct vc feature
-    - python   [win]
-    - gmp      [not win]
+    - vc {{ VC_VERSION }}  # [win]
+    - gmp  # [not win]
 
 test:
   requires:


### PR DESCRIPTION
So, here are some improvements to the way we manage the `vc` problem for Windows.

Ping @msarahan as there are some important implications here.

Things to note / answer:
- [ ] - The `build` component could be handled by conda-build automatically based on the current vc version being used, or alternatively by having yet another special environment variable. 
- [ ] - conda-build-all knows about vc and expands the build matrix to use it and expose as a `VC_VERSION` environment variable
- [ ] - the only reason I'm using features here at all is to give the distributions unique filenames. I want extensibility of the build-string so that I don't have to re-invent the wheel (@msarahan - you may have missed this subtlety in https://github.com/conda/conda-build/pull/747/files#diff-c86934c27c2f25579540ddb447fa45bdR584 with all of the other noise). As soon as I have that, features have no place in this recipe.
