### PR TITLE
Various build fixes

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,6 +3,14 @@
 export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
 export CFLAGS="${CFLAGS} -O3 -I${PREFIX}/include"
 
+if [ "$(uname)" == "Darwin" ];
+then
+    export LDFLAGS="${LDFLAGS} -Wl,-rpath,${PREFIX}/lib"
+elif [ "$(uname)" == "Linux" ];
+then
+    export LDFLAGS="${LDFLAGS} -Wl,-rpath=${PREFIX}/lib"
+fi
+
 ./configure --prefix="${PREFIX}" --with-gmp
 
 make

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,7 +3,7 @@
 export LDFLAGS="-L${PREFIX}/lib"
 export CFLAGS="${CFLAGS} -O3 -I${PREFIX}/include"
 
-./configure --prefix=$PREFIX --with-gmp
+./configure --prefix="${PREFIX}" --with-gmp
 
 make
 make check

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,11 +3,6 @@
 export LDFLAGS="-L${PREFIX}/lib"
 export CFLAGS="${CFLAGS} -O3 -I${PREFIX}/include"
 
-if [ "$(uname)" == "Darwin" ];
-then
-    export LD_LIBRARY_PATH=$PREFIX/lib:$LD_LIBRARY_PATH
-fi
-
 ./configure --prefix=$PREFIX --with-gmp
 
 make

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export LDFLAGS="-L${PREFIX}/lib"
+export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
 export CFLAGS="${CFLAGS} -O3 -I${PREFIX}/include"
 
 ./configure --prefix="${PREFIX}" --with-gmp

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,10 +6,6 @@ export CFLAGS="${CFLAGS} -O3 -I${PREFIX}/include"
 if [ "$(uname)" == "Darwin" ];
 then
     export LD_LIBRARY_PATH=$PREFIX/lib:$LD_LIBRARY_PATH
-    if [ $TRAVIS ];
-    then
-        brew uninstall gmp
-    fi
 fi
 
 ./configure --prefix=$PREFIX --with-gmp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,6 @@ requirements:
     - gmp         # [not win]
 
   run:
-    # python is a Windows run dependency in order to get the correct vc feature
-    - python      # [win]
     - gmp         # [not win]
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-   number: 0
+   number: 1
    features:
      - vc9   # [win and py27]
      - vc10  # [win and py34]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,13 +20,14 @@ build:
 
 requirements:
   build:
-    - python  # [win]
-    - gmp     # [not win]
+    - toolchain
+    - python      # [win]
+    - gmp         # [not win]
 
   run:
     # python is a Windows run dependency in order to get the correct vc feature
-    - python  # [win]
-    - gmp     # [not win]
+    - python      # [win]
+    - gmp         # [not win]
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,10 +22,10 @@ requirements:
   build:
     - toolchain
     - python      # [win]
-    - gmp         # [not win]
+    - gmp 6.1.*   # [not win]
 
   run:
-    - gmp         # [not win]
+    - gmp 6.1.*   # [not win]
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
 
 test:
   requires:
+    - toolchain
     - python
     - setuptools
   files:

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,5 +1,13 @@
-cc -I $PREFIX/include -L $PREFIX/lib test.c -lglpk -o test.out
-# Required on OS X to resolve @rpath/./libglpk.40.dylib
-# If this was a real program use install_name_tool to fix the linkage
-export LD_LIBRARY_PATH=$PREFIX/lib
+export CFLAGS="${CFLAGS} -I${PREFIX}/include -L${PREFIX}/lib"
+
+if [ "$(uname)" == "Darwin" ];
+then
+    export LDFLAGS="${LDFLAGS} -Wl,-rpath,${PREFIX}/lib"
+elif [ "$(uname)" == "Linux" ];
+then
+    export LDFLAGS="${LDFLAGS} -Wl,-rpath=${PREFIX}/lib"
+fi
+
+cc ${CFLAGS} ${LDFLAGS} test.c -lglpk -o test.out
+
 ./test.out


### PR DESCRIPTION
Makes various improvements to the build like using the `toolchain`, not using Homebrew to install `gmp`, and avoiding `LD_LIBRARY_PATH` as it is forbidden by SIP on macOS 10.12.