### PR TITLE
Release 4.62

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "glpk" %}
 {% set version = "4.61" %}
+{% set build = 0 %}
 {% set sha256 = "9866de41777782d4ce21da11b88573b66bb7858574f89c28be6967ac22dfaba9" %}
 
 package:
@@ -12,7 +13,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-   number: 1
+   number: {{ build }}
    features:
      - vc9   # [win and py27]
      - vc10  # [win and py34]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "glpk" %}
-{% set version = "4.61" %}
+{% set version = "4.62" %}
 {% set build = 0 %}
-{% set sha256 = "9866de41777782d4ce21da11b88573b66bb7858574f89c28be6967ac22dfaba9" %}
+{% set sha256 = "096e4be3f83878ccf70e1fdb62ad1c178715ef8c0d244254c29e2f9f0c1afa70" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
```
The bound perturbation technique was included in the primal
simplex solver to improve numerical stability and avoid cycling.
Currently this feature is enabled by default.

A range bug was fixed in the MPS reading routine. Thanks to
Chris Matrakidis <address@hidden> for bug report and patch.

Changes were made to provide 64-bit portability of the Minisat
solver. Thanks to Chris Matrakidis <address@hidden> for
patch.

Calls to non-thread-safe functions gmtime, strerror, and strtok
were replaced by calls to corresponding thread-safe equivalents
(gmtime_r, strerror_r, and strtok_r for GNU/Linux).
```