### PR TITLE
Fix Windows VCs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,14 +18,6 @@ environment:
       CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
     - TARGET_ARCH: x86
-      CONDA_PY: 35
-      CONDA_INSTALL_LOCN: C:\\Miniconda35
-
-    - TARGET_ARCH: x64
-      CONDA_PY: 35
-      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
-
-    - TARGET_ARCH: x86
       CONDA_PY: 36
       CONDA_INSTALL_LOCN: C:\\Miniconda36
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,7 @@ build:
      - vc9   # [win and py27]
      - vc10  # [win and py34]
      - vc14  # [win and py35]
+     - vc14  # [win and py36]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,12 +13,13 @@ source:
   sha256: {{ sha256 }}
 
 build:
+   skip: true  # [win and py35]
    number: {{ build }}
    features:
-     - vc9   # [win and py27]
-     - vc10  # [win and py34]
-     - vc14  # [win and py35]
-     - vc14  # [win and py36]
+     - vc9     # [win and py27]
+     - vc10    # [win and py34]
+     - vc14    # [win and py35]
+     - vc14    # [win and py36]
 
 requirements:
   build:


### PR DESCRIPTION
Appears we got Python 3.6 added without a VC feature. Have pulled all packages produced by this error. This provides a VC feature for Python 3.6 and drops Python 3.5 builds (as it has the same VC feature as Python 3.6). No changes for any other non-Windows platforms.

Note: CIs are not really required for a merge here, but wanted to check that AppVeyor is now setup correctly.